### PR TITLE
로깅 개선 및 네트워크 볼륨 사용 관련 파일 처리 개선

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -279,7 +279,13 @@ def calculate_max_frames_from_audio(wav_path, wav_path_2=None, fps=25):
 def handler(job):
     job_input = job.get("input", {})
 
-    logger.info(f"Received job input: {job_input}")
+    # job_input을 로깅할 때 base64 데이터는 truncate해서 출력
+    log_input = job_input.copy()
+    for key in ["image_base64", "video_base64", "wav_base64", "wav_base64_2"]:
+        if key in log_input:
+            log_input[key] = truncate_base64_for_log(log_input[key])
+
+    logger.info(f"Received job input: {log_input}")
     task_id = f"task_{uuid.uuid4()}"
 
     # 입력 타입과 인물 수 확인


### PR DESCRIPTION
* 로깅 개선 
* 결과 파일을 항상 base64 인코딩 했다가 디코딩 하는 식으로 사용하고 있었는데 path 반환 후 필요한 경우에만 인코딩 하도록 변경했습니다.